### PR TITLE
커서 모드 구현

### DIFF
--- a/macos-cursor-controller/swiftForNoddy/cursorEventHelper.swift
+++ b/macos-cursor-controller/swiftForNoddy/cursorEventHelper.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Quartz
 
-struct mouseEventHelper {
+struct cursorEventHelper {
     private static var lastClickTime: TimeInterval = 0
     private static let doubleClickThreshold: TimeInterval = 0.3
 

--- a/macos-cursor-controller/swiftForNoddy/cursorEventHelper.swift
+++ b/macos-cursor-controller/swiftForNoddy/cursorEventHelper.swift
@@ -2,37 +2,42 @@ import AppKit
 import Quartz
 
 struct cursorEventHelper {
-    private static var lastClickTime: TimeInterval = 0
-    private static let doubleClickThreshold: TimeInterval = 0.3
+    private static var lastClickTime: CFAbsoluteTime = 0
+    private static var clickCount: Int = 0
 
-    static func leftClickAtCurrentCursor() {
-        let currentTime: TimeInterval = Date().timeIntervalSince1970
-        let timeSinceLastClick: TimeInterval = currentTime - lastClickTime
-
-        if timeSinceLastClick < doubleClickThreshold {
-            click(mouseTypeDown: .leftMouseDown, mouseTypeUp: .leftMouseUp, button: .left, clickCount: 2)
+    static func leftMouseDownAtCursor() {
+        let currentTime: CFAbsoluteTime = CFAbsoluteTimeGetCurrent()
+        let timeSinceLastClick: CFAbsoluteTime = currentTime - lastClickTime
+        if timeSinceLastClick < NSEvent.doubleClickInterval {
+            clickCount = min(clickCount + 1, clickCount + 2)
         } else {
-            click(mouseTypeDown: .leftMouseDown, mouseTypeUp: .leftMouseUp, button: .left, clickCount: 1)
+            clickCount = 1
         }
 
         lastClickTime = currentTime
-    }
-    static func rightClickAtCurrentCursor() {
-        click(mouseTypeDown: .rightMouseDown, mouseTypeUp: .rightMouseUp, button: .right, clickCount: 1)
+        click(mouseType: .leftMouseDown, button: .left, clickCount: clickCount)
     }
 
-    private static func click(mouseTypeDown: CGEventType, mouseTypeUp: CGEventType, button: CGMouseButton, clickCount: Int) {
+    static func leftMouseUpAtCursor() {
+        click(mouseType: .leftMouseUp, button: .left, clickCount: clickCount)
+    }
+
+    static func rightMouseDownAtCursor() {
+        click(mouseType: .rightMouseDown, button: .right)
+    }
+
+    static func rightMouseUpAtCursor() {
+        click(mouseType: .rightMouseUp, button: .right)
+    }
+
+    private static func click(mouseType: CGEventType, button: CGMouseButton, clickCount: Int = 1) {
         let screenHeight: CGFloat = NSScreen.screens.first?.frame.height ?? 0
         let location: NSPoint = NSEvent.mouseLocation
         let flippedLocation: CGPoint = CGPoint(x: location.x, y: screenHeight - location.y)
 
-        let mouseDown: CGEvent? = CGEvent(mouseEventSource: nil, mouseType: mouseTypeDown, mouseCursorPosition: flippedLocation, mouseButton: button)
-        let mouseUp: CGEvent? = CGEvent(mouseEventSource: nil, mouseType: mouseTypeUp, mouseCursorPosition: flippedLocation, mouseButton: button)
-
-        mouseDown?.setIntegerValueField(.mouseEventClickState, value: Int64(clickCount))
-        mouseUp?.setIntegerValueField(.mouseEventClickState, value: Int64(clickCount))
-
-        mouseDown?.post(tap: .cghidEventTap)
-        mouseUp?.post(tap: .cghidEventTap)
+        if let event = CGEvent(mouseEventSource: nil, mouseType: mouseType, mouseCursorPosition: flippedLocation, mouseButton: button) {
+            event.setIntegerValueField(.mouseEventClickState, value: Int64(clickCount))
+            event.post(tap: .cghidEventTap)
+        }
     }
 }

--- a/macos-cursor-controller/swiftForNoddy/main.swift
+++ b/macos-cursor-controller/swiftForNoddy/main.swift
@@ -7,8 +7,8 @@ let motionManager = CMHeadphoneMotionManager()
 var motionPaused = false
 
 var pitchForScroll: CGFloat = 0
-let pitchOffset = 0.0
-let yawOffset = 0.0
+var pitchOffset = 0.0
+var yawOffset = 0.0
 
 var cursorSensitivity = 5.5
 

--- a/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
+++ b/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
@@ -35,6 +35,16 @@ func startKeyEventMonitor() {
                             if type == .keyDown {
                                 motionPaused.toggle()
                             }
+                        } else if keyCode == 116 {
+                            if type == .keyDown {
+                                cursorSensitvity = cursorSensitvity + 0.5
+                            }
+                        } else if keyCode == 121 {
+                            if type == .keyDown {
+                                if cursorSensitvity > 0.5 {
+                                    cursorSensitvity = cursorSensitvity - 0.5
+                                }
+                            }
                         }
                     } else {
 

--- a/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
+++ b/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
@@ -19,19 +19,19 @@ func startKeyEventMonitor() {
                     print("모드 : \(isCursorMode ? "Cursor Mode" : "Scroll Mode")")
                 } else {
                     if isCursorMode {
-                        if keyCode == 123 {
+                        if keyCode == 101 {
                             if type == .keyDown {
                                 cursorEventHelper.leftMouseDownAtCursor()
                             } else if type == .keyUp {
                                 cursorEventHelper.leftMouseUpAtCursor()
                             }
-                        } else if keyCode == 124 {
+                        } else if keyCode == 109 {
                             if type == .keyDown {
                                 cursorEventHelper.rightMouseDownAtCursor()
                             } else if type == .keyUp {
                                 cursorEventHelper.rightMouseUpAtCursor()
                             }
-                        } else if keyCode == 125 {
+                        } else if keyCode == 103 {
                             if type == .keyDown {
                                 motionPaused.toggle()
                             }
@@ -44,6 +44,22 @@ func startKeyEventMonitor() {
                                 if cursorSensitvity > 0.5 {
                                     cursorSensitvity = cursorSensitvity - 0.5
                                 }
+                            }
+                        } else if keyCode == 126 {
+                            if type == .keyDown {
+                                pitchOffset = pitchOffset + 0.01
+                            }
+                        } else if keyCode == 125 {
+                            if type == .keyDown {
+                                pitchOffset = pitchOffset - 0.01
+                            }
+                        } else if keyCode == 123 {
+                            if type == .keyDown {
+                                yawOffset = yawOffset - 0.01
+                            }
+                        } else if keyCode == 124 {
+                            if type == .keyDown {
+                                yawOffset = yawOffset + 0.01
                             }
                         }
                     } else {

--- a/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
+++ b/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
@@ -3,7 +3,6 @@ import Quartz
 var isCursorMode: Bool = true
 
 func startKeyEventMonitor() {
-    print()
     let eventMask: Int = (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
 
     guard let eventTap: CFMachPort = CGEvent.tapCreate(
@@ -31,6 +30,10 @@ func startKeyEventMonitor() {
                                 cursorEventHelper.rightMouseDownAtCursor()
                             } else if type == .keyUp {
                                 cursorEventHelper.rightMouseUpAtCursor()
+                            }
+                        } else if keyCode == 125 {
+                            if type == .keyDown {
+                                motionPaused.toggle()
                             }
                         }
                     } else {

--- a/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
+++ b/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
@@ -14,57 +14,53 @@ func startKeyEventMonitor() {
                 let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
                 let flags = event.flags
 
-                if keyCode == 48 && flags.contains(.maskControl) {
+                if keyCode == 48 && flags.contains(.maskControl) && type == .keyDown {
                     isCursorMode.toggle()
                     print("모드 : \(isCursorMode ? "Cursor Mode" : "Scroll Mode")")
-                } else {
-                    if isCursorMode {
-                        if keyCode == 101 {
-                            if type == .keyDown {
-                                cursorEventHelper.leftMouseDownAtCursor()
-                            } else if type == .keyUp {
-                                cursorEventHelper.leftMouseUpAtCursor()
-                            }
-                        } else if keyCode == 109 {
-                            if type == .keyDown {
-                                cursorEventHelper.rightMouseDownAtCursor()
-                            } else if type == .keyUp {
-                                cursorEventHelper.rightMouseUpAtCursor()
-                            }
-                        } else if keyCode == 103 {
-                            if type == .keyDown {
-                                motionPaused.toggle()
-                            }
-                        } else if keyCode == 116 {
-                            if type == .keyDown {
-                                cursorSensitvity = cursorSensitvity + 0.5
-                            }
-                        } else if keyCode == 121 {
-                            if type == .keyDown {
-                                if cursorSensitvity > 0.5 {
-                                    cursorSensitvity = cursorSensitvity - 0.5
-                                }
-                            }
-                        } else if keyCode == 126 {
-                            if type == .keyDown {
-                                pitchOffset = pitchOffset + 0.01
-                            }
-                        } else if keyCode == 125 {
-                            if type == .keyDown {
-                                pitchOffset = pitchOffset - 0.01
-                            }
-                        } else if keyCode == 123 {
-                            if type == .keyDown {
-                                yawOffset = yawOffset - 0.01
-                            }
-                        } else if keyCode == 124 {
-                            if type == .keyDown {
-                                yawOffset = yawOffset + 0.01
-                            }
-                        }
-                    } else {
+                }
 
+                if isCursorMode {
+                    switch keyCode {
+                    case 101 where type == .keyDown:
+                        cursorEventHelper.leftMouseDownAtCursor()
+
+                    case 101 where type == .keyUp:
+                        cursorEventHelper.leftMouseUpAtCursor()
+
+                    case 109 where type == .keyDown:
+                        cursorEventHelper.rightMouseDownAtCursor()
+
+                    case 109 where type == .keyUp:
+                        cursorEventHelper.rightMouseUpAtCursor()
+
+                    case 103 where type == .keyDown:
+                        motionPaused.toggle()
+
+                    case 116 where type == .keyDown:
+                        cursorSensitivity += 0.5
+
+                    case 121 where type == .keyDown:
+                        if cursorSensitivity > 0.5 {
+                            cursorSensitivity -= 0.5
+                        }
+
+                    case 126 where type == .keyDown:
+                        pitchOffset += 0.01
+
+                    case 125 where type == .keyDown:
+                        pitchOffset -= 0.01
+
+                    case 123 where type == .keyDown:
+                        yawOffset -= 0.01
+
+                    case 124 where type == .keyDown:
+                        yawOffset += 0.01
+
+                    default:
+                        break
                     }
+                } else {
+
                 }
             return Unmanaged.passRetained(event)
         },

--- a/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
+++ b/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
@@ -4,7 +4,7 @@ var isCursorMode: Bool = true
 
 func startKeyEventMonitor() {
     print()
-    let eventMask: Int = (1 << CGEventType.keyDown.rawValue)
+    let eventMask: Int = (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
 
     guard let eventTap: CFMachPort = CGEvent.tapCreate(
         tap: .cgSessionEventTap,
@@ -12,7 +12,6 @@ func startKeyEventMonitor() {
         options: .defaultTap,
         eventsOfInterest: CGEventMask(eventMask),
         callback: { _, type, event, _ in
-            if type == .keyDown {
                 let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
                 let flags = event.flags
 
@@ -22,16 +21,22 @@ func startKeyEventMonitor() {
                 } else {
                     if isCursorMode {
                         if keyCode == 123 {
-                            cursorEventHelper.leftClickAtCurrentCursor()
+                            if type == .keyDown {
+                                cursorEventHelper.leftMouseDownAtCursor()
+                            } else if type == .keyUp {
+                                cursorEventHelper.leftMouseUpAtCursor()
+                            }
                         } else if keyCode == 124 {
-                            cursorEventHelper.rightClickAtCurrentCursor()
+                            if type == .keyDown {
+                                cursorEventHelper.rightMouseDownAtCursor()
+                            } else if type == .keyUp {
+                                cursorEventHelper.rightMouseUpAtCursor()
+                            }
                         }
                     } else {
 
                     }
                 }
-
-            }
             return Unmanaged.passRetained(event)
         },
         userInfo: nil

--- a/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
+++ b/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
@@ -1,6 +1,9 @@
 import Quartz
 
+var isCursorMode: Bool = true
+
 func startKeyEventMonitor() {
+    print()
     let eventMask: Int = (1 << CGEventType.keyDown.rawValue)
 
     guard let eventTap: CFMachPort = CGEvent.tapCreate(
@@ -10,13 +13,24 @@ func startKeyEventMonitor() {
         eventsOfInterest: CGEventMask(eventMask),
         callback: { _, type, event, _ in
             if type == .keyDown {
-                let keyCode: Int64 = event.getIntegerValueField(.keyboardEventKeycode)
+                let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+                let flags = event.flags
 
-                if keyCode == 101 {
-                    mouseEventHelper.leftClickAtCurrentCursor()
-                } else if keyCode == 109 {
-                    mouseEventHelper.rightClickAtCurrentCursor()
+                if keyCode == 48 && flags.contains(.maskControl) {
+                    isCursorMode.toggle()
+                    print("모드 : \(isCursorMode ? "Cursor Mode" : "Scroll Mode")")
+                } else {
+                    if isCursorMode {
+                        if keyCode == 123 {
+                            cursorEventHelper.leftClickAtCurrentCursor()
+                        } else if keyCode == 124 {
+                            cursorEventHelper.rightClickAtCurrentCursor()
+                        }
+                    } else {
+
+                    }
                 }
+
             }
             return Unmanaged.passRetained(event)
         },


### PR DESCRIPTION
## 📝 요약(Summary)
**이슈 : #6** 
커서 조작 및 마우스 기능을 수행하는 커서 모드와, 스크롤을 수행하는 스크롤 모드 간 전환은 단축키로 원활하게 이루어지도록 구현했습니다.
또한 커서 모드에서는, 앞서 언급한 바와 같이 기존 마우스가 제공하는 기본 기능들을 각각 구현해 적용했습니다.
### 커서 모드 내 단축키와 할당된 기능 (macOS 한정)
- **모드 변경** : `control ⌃ + Tab ⇥`
- **좌클릭** : `F9`
- **우클릭** : `F10`
- **커서 일시 잠금** : `F11`
- **커서 감도 조**절 : `PageUp / PageDown`
- **커서 위치 조정** : `화살표 ↑ / ↓ / → / ←`

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- 현재 할당되어 있는 단축키는 임시이며 추후 논의를 통하여 변경하는 것이 좋을 것 같습니다.
- 커서 위치 세부조정 외 버튼 하나로 커서 위치를 정중앙에 위치시키는 기능 추가여부 또한 논의해보면 좋을 것 같습니다.
- 드래그 기능은 메인 로직의 마우스 이동 로직 관련 이유로 구현에 제한이 있어 해당 로직에 대해서도 논의해봐야 할 것 같습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 각 이벤트가 할당된 키가 눌릴 시 정상적으로 trigger되는가?
- [x] 좌 / 우클릭
- [x] 더블 / 트리플클릭
- [x] 커서 일시 잠금
- [x] 커서 민감도 조절
- [x] 커서 위치 조정
- [ ] 드래그
