### PR TITLE
스크롤 모드 파일 메인 로직에 연결 및 리팩터링

### DIFF
--- a/macos-cursor-controller/swiftForNoddy/cursorEventHelper.swift
+++ b/macos-cursor-controller/swiftForNoddy/cursorEventHelper.swift
@@ -31,11 +31,7 @@ struct cursorEventHelper {
     }
 
     private static func click(mouseType: CGEventType, button: CGMouseButton, clickCount: Int = 1) {
-        let screenHeight: CGFloat = NSScreen.screens.first?.frame.height ?? 0
-        let location: NSPoint = NSEvent.mouseLocation
-        let flippedLocation: CGPoint = CGPoint(x: location.x, y: screenHeight - location.y)
-
-        if let event = CGEvent(mouseEventSource: nil, mouseType: mouseType, mouseCursorPosition: flippedLocation, mouseButton: button) {
+        if let event = CGEvent(mouseEventSource: nil, mouseType: mouseType, mouseCursorPosition: currentCursorPos, mouseButton: button) {
             event.setIntegerValueField(.mouseEventClickState, value: Int64(clickCount))
             event.post(tap: .cghidEventTap)
         }

--- a/macos-cursor-controller/swiftForNoddy/cursorEventHelper.swift
+++ b/macos-cursor-controller/swiftForNoddy/cursorEventHelper.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Quartz
 
-struct cursorEventHelper {
+struct CursorEventHelper {
     private static var lastClickTime: CFAbsoluteTime = 0
     private static var clickCount: Int = 0
 

--- a/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
+++ b/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
@@ -5,16 +5,16 @@ var isCursorMode: Bool = true
 let scrollEvent = ScrollEventHelper()
 
 class KeyCode {
-    static let Tab = 48
-    static let F9 = 101
-    static let F10 = 109
-    static let F11 = 103
-    static let PageUp = 116
-    static let PageDown = 121
-    static let ArrowUp = 126
-    static let ArrowDown = 125
-    static let ArrowLeft = 123
-    static let ArrowRight = 124
+    static let TAB: Int = 48
+    static let F9: Int = 101
+    static let F10: Int = 109
+    static let F11: Int = 103
+    static let PAGE_UP: Int = 116
+    static let PAGE_DOWN: Int = 121
+    static let ARROW_UP: Int = 126
+    static let ARROW_DOWN: Int = 125
+    static let ARROW_LEFT: Int = 123
+    static let ARROW_RIGHT: Int = 124
 }
 
 func startKeyEventMonitor() {
@@ -30,7 +30,7 @@ func startKeyEventMonitor() {
                 let keyCodeInt = Int(keyCode)
                 let controlKey = event.flags.contains(.maskControl)
 
-                if keyCode == KeyCode.Tab && controlKey && type == .keyDown {
+                if keyCode == KeyCode.TAB && controlKey && type == .keyDown {
                     isCursorMode.toggle()
                     motionPaused.toggle()
                 }
@@ -40,38 +40,38 @@ func startKeyEventMonitor() {
                 scrollEvent.stopMonitoring()
                 switch keyCodeInt {
                 case KeyCode.F9 where type == .keyDown:
-                    cursorEventHelper.leftMouseDownAtCursor()
+                    CursorEventHelper.leftMouseDownAtCursor()
 
                 case KeyCode.F9 where type == .keyUp:
-                    cursorEventHelper.leftMouseUpAtCursor()
+                    CursorEventHelper.leftMouseUpAtCursor()
 
                 case KeyCode.F10 where type == .keyDown:
-                    cursorEventHelper.rightMouseDownAtCursor()
+                    CursorEventHelper.rightMouseDownAtCursor()
 
                 case KeyCode.F10 where type == .keyUp:
-                    cursorEventHelper.rightMouseUpAtCursor()
+                    CursorEventHelper.rightMouseUpAtCursor()
 
                 case KeyCode.F11 where type == .keyDown:
                     motionPaused.toggle()
 
-                case KeyCode.PageUp where type == .keyDown:
-                    cursorSensitivity += 0.5
+                case KeyCode.PAGE_UP where type == .keyDown:
+                    CursorSensitivity += 0.5
 
-                case KeyCode.PageDown where type == .keyDown:
+                case KeyCode.PAGE_DOWN where type == .keyDown:
                     if cursorSensitivity > 0.5 {
                         cursorSensitivity -= 0.5
                     }
 
-                case KeyCode.ArrowUp where type == .keyDown:
+                case KeyCode.ARROW_UP where type == .keyDown:
                     pitchOffset += 0.01
 
-                case KeyCode.ArrowDown where type == .keyDown:
+                case KeyCode.ARROW_DOWN where type == .keyDown:
                     pitchOffset -= 0.01
 
-                case KeyCode.ArrowLeft where type == .keyDown:
+                case KeyCode.ARROW_LEFT where type == .keyDown:
                     yawOffset -= 0.01
 
-                case KeyCode.ArrowRight where type == .keyDown:
+                case KeyCode.ARROW_RIGHT where type == .keyDown:
                     yawOffset += 0.01
 
                 default:

--- a/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
+++ b/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
@@ -4,6 +4,19 @@ var isCursorMode: Bool = true
 
 let scrollEvent = ScrollEventHelper()
 
+class KeyCode {
+    static let Tab = 48
+    static let F9 = 101
+    static let F10 = 109
+    static let F11 = 103
+    static let PageUp = 116
+    static let PageDown = 121
+    static let ArrowUp = 126
+    static let ArrowDown = 125
+    static let ArrowLeft = 123
+    static let ArrowRight = 124
+}
+
 func startKeyEventMonitor() {
     let eventMask: Int = (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
 
@@ -14,63 +27,63 @@ func startKeyEventMonitor() {
         eventsOfInterest: CGEventMask(eventMask),
         callback: { _, type, event, _ in
                 let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
-                let flags = event.flags
+                let keyCodeInt = Int(keyCode)
+                let controlKey = event.flags.contains(.maskControl)
 
-                if keyCode == 48 && flags.contains(.maskControl) && type == .keyDown {
+                if keyCode == KeyCode.Tab && controlKey && type == .keyDown {
                     isCursorMode.toggle()
                     motionPaused.toggle()
-                    print("모드 : \(isCursorMode ? "Cursor Mode" : "Scroll Mode")")
                 }
 
-                if isCursorMode {
-                    scrollEvent.stopMonitoring()
-                    switch keyCode {
-                    case 101 where type == .keyDown:
-                        cursorEventHelper.leftMouseDownAtCursor()
+            switch isCursorMode {
+            case true:
+                scrollEvent.stopMonitoring()
+                switch keyCodeInt {
+                case KeyCode.F9 where type == .keyDown:
+                    cursorEventHelper.leftMouseDownAtCursor()
 
-                    case 101 where type == .keyUp:
-                        cursorEventHelper.leftMouseUpAtCursor()
+                case KeyCode.F9 where type == .keyUp:
+                    cursorEventHelper.leftMouseUpAtCursor()
 
-                    case 109 where type == .keyDown:
-                        cursorEventHelper.rightMouseDownAtCursor()
+                case KeyCode.F10 where type == .keyDown:
+                    cursorEventHelper.rightMouseDownAtCursor()
 
-                    case 109 where type == .keyUp:
-                        cursorEventHelper.rightMouseUpAtCursor()
+                case KeyCode.F10 where type == .keyUp:
+                    cursorEventHelper.rightMouseUpAtCursor()
 
-                    case 103 where type == .keyDown:
-                        motionPaused.toggle()
+                case KeyCode.F11 where type == .keyDown:
+                    motionPaused.toggle()
 
-                    case 116 where type == .keyDown:
-                        cursorSensitivity += 0.5
+                case KeyCode.PageUp where type == .keyDown:
+                    cursorSensitivity += 0.5
 
-                    case 121 where type == .keyDown:
-                        if cursorSensitivity > 0.5 {
-                            cursorSensitivity -= 0.5
-                        }
-
-                    case 126 where type == .keyDown:
-                        pitchOffset += 0.01
-
-                    case 125 where type == .keyDown:
-                        pitchOffset -= 0.01
-
-                    case 123 where type == .keyDown:
-                        yawOffset -= 0.01
-
-                    case 124 where type == .keyDown:
-                        yawOffset += 0.01
-
-                    default:
-                        break
+                case KeyCode.PageDown where type == .keyDown:
+                    if cursorSensitivity > 0.5 {
+                        cursorSensitivity -= 0.5
                     }
-                } else if !isCursorMode {
-                    scrollEvent.startMonitoring()
+
+                case KeyCode.ArrowUp where type == .keyDown:
+                    pitchOffset += 0.01
+
+                case KeyCode.ArrowDown where type == .keyDown:
+                    pitchOffset -= 0.01
+
+                case KeyCode.ArrowLeft where type == .keyDown:
+                    yawOffset -= 0.01
+
+                case KeyCode.ArrowRight where type == .keyDown:
+                    yawOffset += 0.01
+
+                default:
+                    break
                 }
+            case false:
+                scrollEvent.startMonitoring()
+            }
             return Unmanaged.passRetained(event)
         },
         userInfo: nil
     ) else {
-        print("에러 : 권한 없음")
         exit(1)
     }
 

--- a/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
+++ b/macos-cursor-controller/swiftForNoddy/startKeyEventMonitor.swift
@@ -2,6 +2,8 @@ import Quartz
 
 var isCursorMode: Bool = true
 
+let scrollEvent = ScrollEventHelper()
+
 func startKeyEventMonitor() {
     let eventMask: Int = (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
 
@@ -16,10 +18,12 @@ func startKeyEventMonitor() {
 
                 if keyCode == 48 && flags.contains(.maskControl) && type == .keyDown {
                     isCursorMode.toggle()
+                    motionPaused.toggle()
                     print("모드 : \(isCursorMode ? "Cursor Mode" : "Scroll Mode")")
                 }
 
                 if isCursorMode {
+                    scrollEvent.stopMonitoring()
                     switch keyCode {
                     case 101 where type == .keyDown:
                         cursorEventHelper.leftMouseDownAtCursor()
@@ -59,8 +63,8 @@ func startKeyEventMonitor() {
                     default:
                         break
                     }
-                } else {
-
+                } else if !isCursorMode {
+                    scrollEvent.startMonitoring()
                 }
             return Unmanaged.passRetained(event)
         },


### PR DESCRIPTION
## 📝 요약(Summary)
**이슈: #12**
구현 완료된 별도의 스크롤 모드 로직을 메인 로직에 연결했습니다.
또한 전체적으로 리팩터링 과정을 거쳐 중복 로직 제거 및 코드 스타일 수정 완료했습니다.

- **모드 변경** : `control ⌃ + Tab ⇥`
- 위 모드 변경을 통해 스크롤 모드 전환 시 즉시 커서 조작이 멈추며 스크롤 모드가 실행됩니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- 현재 스크롤 모드 전환 후 다시 커서 모드로 돌아오게 됐을 때 계속해서 스크롤 조작이 되는 버그가 있습니다.
- 논의를 통해서 해당 스크롤 모드 코드 내 해당 버그 관련 로직을 수정해야 할 것 같습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 모드 전환 시 각 모드 로직이 분리되어 정상적으로 실행되는가?
- [x] 리팩토링