### PR TITLE
드래그 버그 수정

### DIFF
--- a/macos-cursor-controller/swiftForNoddy/cursorEventHelper.swift
+++ b/macos-cursor-controller/swiftForNoddy/cursorEventHelper.swift
@@ -8,7 +8,7 @@ struct CursorEventHelper {
         let currentTime: CFAbsoluteTime = CFAbsoluteTimeGetCurrent()
         let timeSinceLastClick: CFAbsoluteTime = currentTime - lastClickTime
         if timeSinceLastClick < NSEvent.doubleClickInterval {
-            clickCount += 1
+            clickCount = min(clickCount + 1, 2)
         } else {
             clickCount = 1
         }

--- a/macos-cursor-controller/swiftForNoddy/cursorEventHelper.swift
+++ b/macos-cursor-controller/swiftForNoddy/cursorEventHelper.swift
@@ -15,10 +15,33 @@ struct CursorEventHelper {
 
         lastClickTime = currentTime
         click(mouseType: .leftMouseDown, button: .left, clickCount: clickCount)
+        simulateDragWhileMouseDown()
     }
 
     static func leftMouseUpAtCursor() {
         click(mouseType: .leftMouseUp, button: .left, clickCount: clickCount)
+    }
+
+    static func leftMouseDragAtCursor(to position: CGPoint) {
+        let dragEvent = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDragged, mouseCursorPosition: position, mouseButton: .left)
+        dragEvent?.setIntegerValueField(.mouseEventClickState, value: Int64(clickCount))
+        dragEvent?.post(tap: .cghidEventTap)
+    }
+
+    static func simulateDragWhileMouseDown(duration: TimeInterval = 1.0, interval: TimeInterval = 0.01) {
+        let endTime = Date().addingTimeInterval(duration)
+        var lastPos = currentCursorPos
+
+        DispatchQueue.global(qos: .userInteractive).async {
+            while Date() < endTime {
+                let currentPos = currentCursorPos
+                if currentPos != lastPos {
+                    leftMouseDragAtCursor(to: currentPos)
+                    lastPos = currentPos
+                }
+                usleep(useconds_t(interval * 1_000_000))
+            }
+        }
     }
 
     static func rightMouseAtCursor(down: Bool) {


### PR DESCRIPTION
## 📝 요약(Summary)
**이슈: #39**
- 기존 커서 좌클릭 단축키 사용 시, 커서 이동 중 드래그가 자연스럽게 작동하지 않는 버그를 수정했습니다.
- 별도의 드래그 함수 추가 및 커서 이동 감지 시 해당 함수 호출 방식으로 개선했습니다.
- clickCount가 제한 시간 내에 무한히 증가하는 문제를 방지하기 위해, 최대 clickCount를 2로 제한하는 로직을 추가했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- 마우스 기본 기능인 일정 시간 내 3회 클릭(트리플 클릭) 시 텍스트 전체 하이라이트 기능 구현을 위해 clickCount 최대값을 3으로 설정했으나
- 새로 추가된 드래그 로직과 충돌로 인해 드래그가 정상 작동하지 않는 문제가 발견되었습니다.
- 현재는 드래그 기능의 우선순위가 높아 트리플 클릭 기능을 제외한 상태입니다.
- 추후 드래그 로직과 충돌하지 않는 방안을 찾아 재도입할 예정입니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 끊기지 않고 자연스럽게 커서 드래그가 일어나는가?
- [ ] 추가 버그사항은 없는가?
