### PR TITLE
AirPods 상태 데이터 연동 처리

### DIFF
--- a/frontend-dashboard/src/components/Body.jsx
+++ b/frontend-dashboard/src/components/Body.jsx
@@ -1,7 +1,7 @@
-import { useMovementStore } from "@/stores/useMovementStore";
+import { usePageStore } from "@/stores/usePageStore";
 
 export default function Body({ children }) {
-  const optionPage = useMovementStore((state) => state.optionPage);
+  const optionPage = usePageStore((state) => state.optionPage);
 
   return (
     <>

--- a/frontend-dashboard/src/components/DeviceInfo.jsx
+++ b/frontend-dashboard/src/components/DeviceInfo.jsx
@@ -1,0 +1,46 @@
+import { useDeviceInfoStore } from "@/stores/useDeviceInfoStore";
+
+function AirPodsInfo() {
+  const { airPodsName, airPodsLeftBattery, airPodsRightBattery } = useDeviceInfoStore();
+
+  return (
+    <div className="mb-[1vh] flex h-[12vh] w-[17vh] flex-col items-center justify-center rounded-2xl bg-gray-200 text-sm dark:bg-gray-800 dark:text-white">
+      <div className="flex h-[3vh] items-center text-xl font-bold">{airPodsName}</div>
+      <div className="flex h-[6vh] flex-col justify-center">
+        <div>
+          <span className="font-semibold">Left: </span>
+          {airPodsLeftBattery}%
+        </div>
+        <div>
+          <span className="font-semibold">Right: </span>
+          {airPodsRightBattery}%
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MacInfo() {
+  const macBattery = useDeviceInfoStore((state) => state.macBattery);
+
+  return (
+    <div className="flex h-[12vh] w-[17vh] flex-col items-center justify-center rounded-2xl bg-gray-200 text-sm dark:bg-gray-800 dark:text-white">
+      <div className="flex h-[3vh] items-center text-xl font-bold">Mac</div>
+      <div className="flex h-[6vh] flex-col justify-center">
+        <div>
+          <span className="font-semibold">Battery: </span>
+          {macBattery}%
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function DeviceInfo() {
+  return (
+    <div className="flex flex-col">
+      <AirPodsInfo />
+      <MacInfo />
+    </div>
+  );
+}

--- a/frontend-dashboard/src/components/Footer.jsx
+++ b/frontend-dashboard/src/components/Footer.jsx
@@ -1,7 +1,9 @@
+import { useDeviceInfoStore } from "@/stores/useDeviceInfoStore";
 import ThreeDimensionalImage from "@/components/ThreeDimensionalImage";
 import Model3D from "@/components/Model3D";
 
 export default function Footer() {
+  const { macBattery, airPodsName, airPodsLeftBattery, airPodsRightBattery } = useDeviceInfoStore();
   const VALUE_ROTATING_MODEL_FORWARD = 3.8;
 
   return (
@@ -9,10 +11,11 @@ export default function Footer() {
       <div className="h-[25vh] w-[25vh] overflow-hidden rounded-2xl">
         <ThreeDimensionalImage model={<Model3D direction={VALUE_ROTATING_MODEL_FORWARD} />} />
       </div>
-      <div className="flex h-[25vh] w-[14vh] flex-col items-center justify-center rounded-2xl bg-gray-200 dark:bg-gray-800 dark:text-white">
-        <div className="flex justify-center">AirPods</div>
-        <div className="pl-2">Name: Name</div>
-        <div className="pl-2">Battery: 90%</div>
+      <div className="flex h-[25vh] w-[17vh] flex-col items-center justify-center rounded-2xl bg-gray-200 text-sm dark:bg-gray-800 dark:text-white">
+        <div className="flex justify-center">Name : {airPodsName}</div>
+        <div className="flex justify-center">Mac Battery: {macBattery}%</div>
+        <div className="flex justify-center">Left: {airPodsLeftBattery}%</div>
+        <div className="flex justify-center">Right: {airPodsRightBattery}%</div>
       </div>
     </div>
   );

--- a/frontend-dashboard/src/components/Footer.jsx
+++ b/frontend-dashboard/src/components/Footer.jsx
@@ -1,9 +1,8 @@
-import { useDeviceInfoStore } from "@/stores/useDeviceInfoStore";
 import ThreeDimensionalImage from "@/components/ThreeDimensionalImage";
 import Model3D from "@/components/Model3D";
+import DeviceInfo from "@/components/DeviceInfo";
 
 export default function Footer() {
-  const { macBattery, airPodsName, airPodsLeftBattery, airPodsRightBattery } = useDeviceInfoStore();
   const VALUE_ROTATING_MODEL_FORWARD = 3.8;
 
   return (
@@ -11,12 +10,7 @@ export default function Footer() {
       <div className="h-[25vh] w-[25vh] overflow-hidden rounded-2xl">
         <ThreeDimensionalImage model={<Model3D direction={VALUE_ROTATING_MODEL_FORWARD} />} />
       </div>
-      <div className="flex h-[25vh] w-[17vh] flex-col items-center justify-center rounded-2xl bg-gray-200 text-sm dark:bg-gray-800 dark:text-white">
-        <div className="flex justify-center">Name : {airPodsName}</div>
-        <div className="flex justify-center">Mac Battery: {macBattery}%</div>
-        <div className="flex justify-center">Left: {airPodsLeftBattery}%</div>
-        <div className="flex justify-center">Right: {airPodsRightBattery}%</div>
-      </div>
+      <DeviceInfo />
     </div>
   );
 }

--- a/frontend-dashboard/src/components/Header.jsx
+++ b/frontend-dashboard/src/components/Header.jsx
@@ -1,8 +1,8 @@
-import { useMovementStore } from "@/stores/useMovementStore";
+import { usePageStore } from "@/stores/usePageStore";
 import { CursorArrowRippleIcon, ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 
 export default function Header() {
-  const setOptionPage = useMovementStore((state) => state.setOptionPage);
+  const setOptionPage = usePageStore((state) => state.setOptionPage);
 
   return (
     <>

--- a/frontend-dashboard/src/hooks/useSocket.jsx
+++ b/frontend-dashboard/src/hooks/useSocket.jsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useRef } from "react";
 import { useMovementStore } from "@/stores/useMovementStore";
+import { useDeviceInfoStore } from "@/stores/useDeviceInfoStore";
 import fetchClientId from "@/api/fetchClientId";
 
 export default function useSocket() {
   const [clientId, setClientId] = useState(null);
   const socketRef = useRef(null);
   const { setPitch, setYaw } = useMovementStore();
+  const { setMacBattery, setAirPodsName, setAirPodsLeftBattery, setAirPodsRightBattery } = useDeviceInfoStore();
 
   useEffect(() => {
     const getClientId = async () => {
@@ -27,6 +29,10 @@ export default function useSocket() {
           const message = JSON.parse(event.data);
           setPitch(message.pitch);
           setYaw(message.yaw);
+          setMacBattery(message.macBattery);
+          setAirPodsName(message.name);
+          setAirPodsLeftBattery(message.airpodLeftBattery);
+          setAirPodsRightBattery(message.airpodRightBattery);
         } catch (e) {
           console.warn("❗데이터 타입이 JSON이 아닙니다.", event.data);
           return;

--- a/frontend-dashboard/src/layouts/OptionPageLayout.jsx
+++ b/frontend-dashboard/src/layouts/OptionPageLayout.jsx
@@ -1,4 +1,4 @@
-import { useMovementStore } from "@/stores/useMovementStore";
+import { usePageStore } from "@/stores/usePageStore";
 import Body from "@/components/Body";
 import CursorModeOptions from "@/pages/cursorMode/CursorModeOptions";
 import Footer from "@/components/Footer";
@@ -6,7 +6,7 @@ import Header from "@/components/Header";
 import ScrollModeOptions from "@/pages/scrollMode/ScrollModeOptions";
 
 export default function OptionPageLayout() {
-  const optionPage = useMovementStore((state) => state.optionPage);
+  const optionPage = usePageStore((state) => state.optionPage);
 
   const renderOption = () => {
     switch (optionPage) {

--- a/frontend-dashboard/src/stores/useDeviceInfoStore.js
+++ b/frontend-dashboard/src/stores/useDeviceInfoStore.js
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+export const useDeviceInfoStore = create((set) => ({
+  airPodsName: "N/A",
+  airPodsLeftBattery: 0,
+  airPodsRightBattery: 0,
+  macBattery: 0,
+
+  setAirPodsName: (airPodsName) => set({ airPodsName }),
+  setAirPodsLeftBattery: (airPodsLeftBattery) => set({ airPodsLeftBattery }),
+  setairPodsRightBattery: (airPodsRightBattery) => set({ airPodsRightBattery }),
+  setMacBattery: (macBattery) => set({ macBattery }),
+}));

--- a/frontend-dashboard/src/stores/useDeviceInfoStore.js
+++ b/frontend-dashboard/src/stores/useDeviceInfoStore.js
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 
 export const useDeviceInfoStore = create((set) => ({
-  airPodsName: "N/A",
+  airPodsName: "AirPods",
   airPodsLeftBattery: 0,
   airPodsRightBattery: 0,
   macBattery: 0,

--- a/frontend-dashboard/src/stores/useDeviceInfoStore.js
+++ b/frontend-dashboard/src/stores/useDeviceInfoStore.js
@@ -8,6 +8,6 @@ export const useDeviceInfoStore = create((set) => ({
 
   setAirPodsName: (airPodsName) => set({ airPodsName }),
   setAirPodsLeftBattery: (airPodsLeftBattery) => set({ airPodsLeftBattery }),
-  setairPodsRightBattery: (airPodsRightBattery) => set({ airPodsRightBattery }),
+  setAirPodsRightBattery: (airPodsRightBattery) => set({ airPodsRightBattery }),
   setMacBattery: (macBattery) => set({ macBattery }),
 }));

--- a/frontend-dashboard/src/stores/useMovementStore.js
+++ b/frontend-dashboard/src/stores/useMovementStore.js
@@ -1,11 +1,9 @@
 import { create } from "zustand";
 
 export const useMovementStore = create((set) => ({
-  optionPage: "Cursor",
   pitch: 0.5,
   yaw: 0.5,
 
-  setOptionPage: (optionPage) => set({ optionPage }),
   setPitch: (pitch) => set({ pitch }),
   setYaw: (yaw) => set({ yaw }),
 }));

--- a/frontend-dashboard/src/stores/usePageStore.js
+++ b/frontend-dashboard/src/stores/usePageStore.js
@@ -1,0 +1,7 @@
+import { create } from "zustand";
+
+export const usePageStore = create((set) => ({
+  optionPage: "Cursor",
+
+  setOptionPage: (optionPage) => set({ optionPage }),
+}));

--- a/macos-cursor-controller/swiftForNoddy/airPodsInfoTeller.swift
+++ b/macos-cursor-controller/swiftForNoddy/airPodsInfoTeller.swift
@@ -1,0 +1,64 @@
+import IOBluetooth
+import IOKit.ps
+
+func fetchPairedAirPodsName() -> String? {
+    if let devices = IOBluetoothDevice.pairedDevices() as? [IOBluetoothDevice] {
+        for device in devices {
+            if device.isConnected(), device.name.contains("AirPods") {
+                return device.name
+            }
+        }
+    }
+    return nil
+}
+
+func fetchMacBatteryLevel() -> Int? {
+    let info = IOPSCopyPowerSourcesInfo().takeRetainedValue()
+    let sources: Array<CFTypeRef> = IOPSCopyPowerSourcesList(info).takeRetainedValue() as Array
+    guard let source = sources.first,
+          let description = IOPSGetPowerSourceDescription(info, source)?.takeUnretainedValue() as? [String: AnyObject],
+          let level = description[kIOPSCurrentCapacityKey] as? Int else {
+        return nil
+    }
+    return level
+}
+
+func runBluetoothBatteryCommand() -> String? {
+    let command = "system_profiler SPBluetoothDataType | grep -i 'Battery Level'"
+    let process = Process()
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+    process.launchPath = "/bin/bash"
+    process.arguments = ["-c", command]
+    process.launch()
+    process.waitUntilExit()
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    return String(data: data, encoding: .utf8)
+}
+
+func parseAirPodsBatteryLevels(from output: String) {
+    output.enumerateLines { line, _ in
+        let cleanedLine = line.lowercased()
+        let value = Int(line.components(separatedBy: CharacterSet.decimalDigits.inverted).joined())
+
+        switch true {
+        case cleanedLine.contains("left"):
+            airPodsLeftBattery = value
+        case cleanedLine.contains("right"):
+            airPodsRightBattery = value
+        default:
+            break
+        }
+    }
+}
+
+func airPodsInfoTeller() {
+    airPodsName = fetchPairedAirPodsName() ?? "N/A"
+    MacBattery = fetchMacBatteryLevel() ?? 0
+
+    if let output = runBluetoothBatteryCommand() {
+        parseAirPodsBatteryLevels(from: output)
+    }
+}

--- a/macos-cursor-controller/swiftForNoddy/globalVariables.swift
+++ b/macos-cursor-controller/swiftForNoddy/globalVariables.swift
@@ -1,5 +1,11 @@
 import Quartz
 
+// airPodsInfoTeller.swift (AirPods Information)
+var airPodsName = ""
+var airPodsLeftBattery: Int?
+var airPodsRightBattery: Int?
+var MacBattery = 0
+
 // motionManager.swift (Motion Data)
 var isMotionPaused = false
 var pitchForScroll: CGFloat = 0

--- a/macos-cursor-controller/swiftForNoddy/main.swift
+++ b/macos-cursor-controller/swiftForNoddy/main.swift
@@ -13,6 +13,7 @@ func moveCursor(to point: CGPoint) {
 webSocketTask.resume()
 receiveDecodedData()
 sendPairingMessage()
+airPodsInfoTeller()
 
 startKeyEventMonitor()
 moveCursor(to: currentCursorPos)
@@ -45,7 +46,10 @@ motionManager.startDeviceMotionUpdates(to: .main) { motion, error in
 
     pitchForScroll = mappedY
 
-    sendMotionData(pitch: pitch, yaw: yaw)
+    let decimalProcessedPitch = Double(Int(normalizedPitch * 100)) / 100
+    let decimalProcessedYaw = Double(Int(normalizedYaw * 100)) / 100
+
+    sendMotionData(pitch: decimalProcessedPitch, yaw: decimalProcessedYaw, name: airPodsName, macBattery: MacBattery, airpodLeftBattery: airPodsLeftBattery ?? 0, airpodRightBattery: airPodsRightBattery ?? 0)
 
     targetCursorPos = CGPoint(x: mappedX, y: mappedY)
 }
@@ -63,16 +67,16 @@ Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { _ in
 }
 
 Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
-    let timeSinceLastMotion = Date().timeIntervalSince(lastMotionTimestamp)
-    let maxInactiveDuration: TimeInterval = 2.0
+   let timeSinceLastMotion = Date().timeIntervalSince(lastMotionTimestamp)
+   let maxInactiveDuration: TimeInterval = 2.0
 
-    if timeSinceLastMotion > maxInactiveDuration {
-        if isWearingAirPods {
-            isWearingAirPods = false
-            print("에어팟 감지 안됨. 프로그램 종료.")
-            exit(0)
-        }
-    }
+   if timeSinceLastMotion > maxInactiveDuration {
+       if isWearingAirPods {
+           isWearingAirPods = false
+           print("에어팟 감지 안됨. 프로그램 종료.")
+           exit(0)
+       }
+   }
 }
 
 RunLoop.main.run()

--- a/macos-cursor-controller/swiftForNoddy/main.swift
+++ b/macos-cursor-controller/swiftForNoddy/main.swift
@@ -13,7 +13,6 @@ func moveCursor(to point: CGPoint) {
 webSocketTask.resume()
 receiveDecodedData()
 sendPairingMessage()
-airPodsInfoTeller()
 
 startKeyEventMonitor()
 moveCursor(to: currentCursorPos)
@@ -77,6 +76,11 @@ Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
            exit(0)
        }
    }
+}
+
+airPodsInfoTeller()
+Timer.scheduledTimer(withTimeInterval: 30.0, repeats: true) { _ in
+    airPodsInfoTeller()
 }
 
 RunLoop.main.run()

--- a/macos-cursor-controller/swiftForNoddy/main.swift
+++ b/macos-cursor-controller/swiftForNoddy/main.swift
@@ -45,10 +45,10 @@ motionManager.startDeviceMotionUpdates(to: .main) { motion, error in
 
     pitchForScroll = mappedY
 
-    let decimalProcessedPitch = Double(Int(normalizedPitch * 100)) / 100
-    let decimalProcessedYaw = Double(Int(normalizedYaw * 100)) / 100
+    let truncatedPitch = Double(Int(normalizedPitch * 100)) / 100
+    let truncatedYaw = Double(Int(normalizedYaw * 100)) / 100
 
-    sendMotionData(pitch: decimalProcessedPitch, yaw: decimalProcessedYaw, name: airPodsName, macBattery: MacBattery, airpodLeftBattery: airPodsLeftBattery ?? 0, airpodRightBattery: airPodsRightBattery ?? 0)
+    sendMotionData(pitch: truncatedPitch, yaw: truncatedYaw, name: airPodsName, macBattery: MacBattery, airpodLeftBattery: airPodsLeftBattery ?? 0, airpodRightBattery: airPodsRightBattery ?? 0)
 
     targetCursorPos = CGPoint(x: mappedX, y: mappedY)
 }

--- a/macos-cursor-controller/swiftForNoddy/webSocket.swift
+++ b/macos-cursor-controller/swiftForNoddy/webSocket.swift
@@ -64,7 +64,7 @@ func receiveDecodedData() {
                             } else if name == "Scroll Speed" {
                                 scrollSensitivity = invertedValue(sliderValue: num, minValue: 550, maxValue: 50)
                             }
-                         }
+                        }
 
                         if decoded.type == "hotkey", let num = decoded.value, let name = decoded.name {
                             if name == "Toggle Mode" {

--- a/macos-cursor-controller/swiftForNoddy/webSocket.swift
+++ b/macos-cursor-controller/swiftForNoddy/webSocket.swift
@@ -31,9 +31,9 @@ func sendPairingMessage() {
     }
 }
 
-func sendMotionData(pitch: Double, yaw: Double) {
-    let payload: [String: Any] = ["type": "motion", "clientId": uuid, "pitch": pitch, "yaw": yaw]
-    
+func sendMotionData(pitch: Double, yaw: Double, name: String, macBattery: Int, airpodLeftBattery: Int, airpodRightBattery: Int) {
+    let payload: [String: Any] = ["type": "motion", "clientId": uuid, "pitch": pitch, "yaw": yaw, "name": name, "macBattery": macBattery, "airpodLeftBattery": airpodLeftBattery, "airpodRightBattery": airpodRightBattery]
+
     if let data = try? JSONSerialization.data(withJSONObject: payload),
        let jsonString = String(data: data, encoding: .utf8) {
         let message = URLSessionWebSocketTask.Message.string(jsonString)
@@ -65,7 +65,7 @@ func receiveDecodedData() {
                                 scrollSensitivity = invertedValue(sliderValue: num, minValue: 550, maxValue: 50)
                             }
                          }
-                        
+
                         if decoded.type == "hotkey", let num = decoded.value, let name = decoded.name {
                             if name == "Toggle Mode" {
                                 keyCodes.toggleMode = Int(num)


### PR DESCRIPTION
## 📝 요약(Summary)
**이슈: #51**
- Swift: 실시간 에어팟 데이터 수집 기능 구현
- Swift: 수집한 데이터를 소켓으로 전송
- React: 소켓 수신 데이터를 state에 바인딩
- React: state 기반 에어팟 정보 표시 컴포넌트 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷
<img width="1512" alt="스크린샷 2025-06-10 오후 9 00 39" src="https://github.com/user-attachments/assets/dc1384c0-cc47-431b-8aa7-ac7a64dbf861" />

## 💬 공유사항 to 리뷰어
- 배터리 잔량 업데이트를 실시간에서 30초 주기로 변경하여 최적화하였습니다.
- 주기 변경에 대한 의견이나 추가 개선 사항이 있으시면 언제든지 공유 부탁드립니다.
- 배터리 관련 데이터는 기존에 존재하는 스토어들과 주제가 달라 별도의 전용 스토어를 새로 생성하였습니다.
- 기존 모션 기반 스토어 내 optionPage 상태도 기존 스토어 주제와 맞지 않아 별도의 스토어로 분리하였습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 앱 실행 시 AirPods 상태를 포함한 정보들이 정상적으로 표시되는가?
- [x] 표시된 정보가 변화에 따라 실시간으로 업데이트되는가?
