### PR TITLE
3D 헤드 이미지 방향 수정

### DIFF
--- a/frontend-dashboard/src/components/3D/Model3D.jsx
+++ b/frontend-dashboard/src/components/3D/Model3D.jsx
@@ -10,7 +10,7 @@ export default function Model3D(props) {
   const isThemeDark = useThemeStore((state) => state.isThemeDark);
   const { pitch, yaw } = useMovementStore();
   const { direction, modelTranslationY } = props;
-  const rotatingDirection = direction === 4.2 ? 1 : -1;
+  const ROTATING_DIRECTION = direction === 4.2 ? 1 : -1;
 
   useEffect(() => {
     scene.traverse((child) => {
@@ -22,8 +22,8 @@ export default function Model3D(props) {
 
   useFrame(() => {
     if (modelRef.current) {
-      modelRef.current.rotation.x = rotatingDirection * (pitch - 0.5) * window.innerWidth * 0.0004;
-      modelRef.current.rotation.y = rotatingDirection * (yaw - direction) * window.innerHeight * 0.001;
+      modelRef.current.rotation.x = ROTATING_DIRECTION * (pitch - 0.5) * window.innerWidth * 0.0004;
+      modelRef.current.rotation.y = ROTATING_DIRECTION * (yaw - direction) * window.innerHeight * 0.001;
     }
   });
 

--- a/frontend-dashboard/src/components/3D/Model3D.jsx
+++ b/frontend-dashboard/src/components/3D/Model3D.jsx
@@ -10,7 +10,7 @@ export default function Model3D(props) {
   const isThemeDark = useThemeStore((state) => state.isThemeDark);
   const { pitch, yaw } = useMovementStore();
   const { direction, modelTranslationY } = props;
-  const rotatingDirection = direction === 3.8 ? 1 : -1;
+  const rotatingDirection = direction === 4.2 ? 1 : -1;
 
   useEffect(() => {
     scene.traverse((child) => {

--- a/frontend-dashboard/src/components/3D/Model3D.jsx
+++ b/frontend-dashboard/src/components/3D/Model3D.jsx
@@ -10,7 +10,9 @@ export default function Model3D(props) {
   const isThemeDark = useThemeStore((state) => state.isThemeDark);
   const { pitch, yaw } = useMovementStore();
   const { direction, modelTranslationY } = props;
-  const ROTATING_DIRECTION = direction === 4.2 ? 1 : -1;
+  const ROTATING_DIRECTION = direction === 3.65 ? 1 : -1;
+  const ROTATION_SCALE_X = 0.4;
+  const ROTATION_SCALE_Y = 1.0;
 
   useEffect(() => {
     scene.traverse((child) => {
@@ -22,8 +24,8 @@ export default function Model3D(props) {
 
   useFrame(() => {
     if (modelRef.current) {
-      modelRef.current.rotation.x = ROTATING_DIRECTION * (pitch - 0.5) * window.innerWidth * 0.0004;
-      modelRef.current.rotation.y = ROTATING_DIRECTION * (yaw - direction) * window.innerHeight * 0.001;
+      modelRef.current.rotation.x = ROTATING_DIRECTION * (pitch - 0.5) * ROTATION_SCALE_X;
+      modelRef.current.rotation.y = ROTATING_DIRECTION * (yaw - direction) * ROTATION_SCALE_Y;
     }
   });
 

--- a/frontend-dashboard/src/components/Footer.jsx
+++ b/frontend-dashboard/src/components/Footer.jsx
@@ -3,7 +3,7 @@ import Model3D from "@/components/3D/Model3D";
 import DeviceInfo from "@/components/DeviceInfo";
 
 export default function Footer() {
-  const VALUE_ROTATING_MODEL_FORWARD = 4.2;
+  const VALUE_ROTATING_MODEL_FORWARD = 3.65;
 
   return (
     <div className="mt-[2vh] flex w-[45vh] items-center justify-between rounded-2xl px-2">

--- a/frontend-dashboard/src/components/Footer.jsx
+++ b/frontend-dashboard/src/components/Footer.jsx
@@ -3,7 +3,7 @@ import Model3D from "@/components/3D/Model3D";
 import DeviceInfo from "@/components/DeviceInfo";
 
 export default function Footer() {
-  const VALUE_ROTATING_MODEL_FORWARD = 3.8;
+  const VALUE_ROTATING_MODEL_FORWARD = 4.2;
 
   return (
     <div className="mt-[2vh] flex w-[45vh] items-center justify-between rounded-2xl px-2">

--- a/frontend-dashboard/src/layouts/OptionPage/ScrollModeOptions.jsx
+++ b/frontend-dashboard/src/layouts/OptionPage/ScrollModeOptions.jsx
@@ -8,7 +8,7 @@ export default function SliderModeOptions() {
   return (
     <>
       <ControlSlider keyName="scrollSpeed" name={t("scrollSpeed")} min={50} max={550} step={10} defaultValue={300} />
-      <ControlKey keyName="scrollPause" name={t("scrollPause")} />
+      <ControlKey keyName="scrollPause" name={t("scrollPause")} defaultValue={"Q"} />
     </>
   );
 }


### PR DESCRIPTION
## 📝 요약(Summary)
**이슈: #74** 
- 옵션 페이지 3D 헤드 이미지가 정면을 바라보도록 방향값 수정
- 화면 크기와 상관없이 방향이 고정되도록 버그 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- 기존 화면 크기에 따라 방향이 바뀌게 되는 에러사항을 수정했습니다.
- 기존 모델 이미지 회전 로직에 포함되던 `window.innerHeight`과 `window.innerWidth` 값 대신 
고정 스케일에 따라 회전하는 방식으로 변경했습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 헤드 이미지 방향이 의도대로 수정되었는가?